### PR TITLE
JOSS Review: Simplify examples

### DIFF
--- a/Examples/D1_ANOVA1rm.m
+++ b/Examples/D1_ANOVA1rm.m
@@ -19,8 +19,8 @@ colorLine{1}=[rgb('green'); rgb('blue'); rgb('red'); rgb('black')];
 independantEffects=[];
 % There are 20 subjects
 
-savedir=[];
-savedir2=[];
+savedir='./D1_ANOVA1rm_results';
+savedir2='./D1_ANOVA1rm_results';
 xlab='Angle (°)';
 ylab='Ratio';
 xlimits=[30 90];

--- a/Examples/D1_ANOVA1rm.m
+++ b/Examples/D1_ANOVA1rm.m
@@ -19,8 +19,8 @@ colorLine{1}=[rgb('green'); rgb('blue'); rgb('red'); rgb('black')];
 independantEffects=[];
 % There are 20 subjects
 
-savedir='./D1_ANOVA1rm_results';
-savedir2='./D1_ANOVA1rm_results';
+savedir='D1_ANOVA1rm_results';
+savedir2='D1_ANOVA1rm_results';
 xlab='Angle (°)';
 ylab='Ratio';
 xlimits=[30 90];

--- a/Examples/D1_ANOVA2_1rm.m
+++ b/Examples/D1_ANOVA2_1rm.m
@@ -23,8 +23,8 @@ lineStyle{1}={'-' '-.'; '--' '--'}; % first row is for the means, second row for
 repeatedMeasuresEffects{1}={'Right','Left'};
 colorLine{2}=[rgb('green'); rgb('red')];
 
-savedir='C:\Users\LIBM_yb\Documents\DATA_MATLAB\spmTest';
-savedir2=[];
+savedir='D1_ANOVA2_1rm_results';
+savedir2='D1_ANOVA2_1rm_results2';
 xlab='Angle (°)';
 ylab='Ratio';
 xlimits=[30 90];

--- a/Examples/D1_ANOVA2_1rm_3x3modal.m
+++ b/Examples/D1_ANOVA2_1rm_3x3modal.m
@@ -24,8 +24,8 @@ repeatedMeasuresEffects{1}={'Intoed','Normal','Outtoed'};
 colorLine{2}=[rgb('green'); rgb('red'); rgb('cyan')];
 
 
-savedir=[];
-savedir2=[];
+savedir='D1_ANOVA2_1rm_3x3modal_results';
+savedir2='D1_ANOVA2_1rm_3x3modal_results2';
 xlab='Angle (°)';
 ylab='Ratio';
 xlimits=[30 90];

--- a/Examples/D1_ANOVA3_2rm.m
+++ b/Examples/D1_ANOVA3_2rm.m
@@ -24,8 +24,8 @@ colorLine{3}=[rgb('gray'); rgb('darkgray')];
 % There are 20 subjects
 % ANOVA3 does not accept unbalanced data (10 males, 10 females)
 
-savedir=[];
-savedir2=[];
+savedir='D1_ANOVA3_2rm_results';
+savedir2='D1_ANOVA3_2rm_results2';
 xlab='Angle (°)';
 ylab='Ratio';
 xlimits=[30 90];

--- a/Examples/D1_independantTtest.m
+++ b/Examples/D1_independantTtest.m
@@ -16,8 +16,8 @@ linestyle{1}={'--' ':'};
 independantEffects{1}={'M','M','M','F','M','F','F','M','F','M','M','F','F','M','F','F','M','F','F','M'}; % same number than participants
 repeatedMeasuresEffects=[]; % empty
 
-savedir=[];
-savedir2=[];
+savedir='D1_independantTtest_results';
+savedir2='D1_independantTtest_results2';
 xlab='Angle (°)';
 ylab='Ratio';
 xlimits=[30 90];

--- a/Examples/D1_pairedTtest.m
+++ b/Examples/D1_pairedTtest.m
@@ -18,8 +18,8 @@ independantEffects=[]; % empty
 repeatedMeasuresEffects{1}={'Right','Left'}; % Side
 
 
-savedir=[];
-savedir2=[];
+savedir='D1_pairedTtest_results';
+savedir2='D1_pairedTtest_results';
 xlab='Angle (°)';
 ylab='Ratio';
 xlimits=[30 90];

--- a/Examples/D2_ANOVA1.m
+++ b/Examples/D2_ANOVA1.m
@@ -21,8 +21,8 @@ effectNames={'Group'};
 % ANOVA1 accepts unbalanced data
 
 
-savedir=[];
-savedir2=[];
+savedir='D2_ANOVA1_results';
+savedir2='D2_ANOVA1_results2';
 xlab='Time (s)';
 ylab='Frequency (Hz)';
 Fs=500;

--- a/Examples/D2_ANOVA1rm.m
+++ b/Examples/D2_ANOVA1rm.m
@@ -22,8 +22,8 @@ effectNames={'Shoes'};
 % Data(:,3) correspond to Shoes=C3
 % Data(:,4) correspond to Shoes=C4
 
-savedir=[];
-savedir2=[];
+savedir='D2_ANOVA1rm_results';
+savedir2='D2_ANOVA1rm_results2';
 xlab='Time (s)';
 ylab='Frequency (Hz)';
 Fs=400;

--- a/Examples/D2_ANOVA2rm.m
+++ b/Examples/D2_ANOVA2rm.m
@@ -22,8 +22,8 @@ effectNames={'Device','Activation'};
 % Data(:,3) correspond to Device=US and Activation=Contracted
 % Data(:,4) correspond to Device=US and Activation=Relaxed
 
-savedir=[];
-savedir2=[];
+savedir='D2_ANOVA2rm_results';
+savedir2='D2_ANOVA2rm_results2';
 xlab='Time (s)';
 ylab='Frequency (Hz)';
 Fs=500;

--- a/Examples/D2_ANOVA3_2rm.m
+++ b/Examples/D2_ANOVA3_2rm.m
@@ -23,8 +23,8 @@ effectNames={'Group','Device','Activation'};
 % Data(:,3) correspond to Device=US and Activation=Contracted
 % Data(:,4) correspond to Device=US and Activation=Relaxed
 
-savedir='C:\Users\LIBM_yb\Documents\DATA_MATLAB\spmTest\1';
-savedir2='C:\Users\LIBM_yb\Documents\DATA_MATLAB\spmTest\2';
+savedir='D2_ANOVA3_2rm_results';
+savedir2='D2_ANOVA3_2rm_results2';
 xlab='Time (s)';
 ylab='Frequency (Hz)';
 Fs=500;

--- a/Examples/D2_independantTtest.m
+++ b/Examples/D2_independantTtest.m
@@ -18,8 +18,8 @@ effectNames={'Group'};
 % There is 15 subjects
 % Subjects 1 to 8 are 'L', and 9 to 15 are 'S'
 
-savedir=[];
-savedir2=[];
+savedir='D2_independantTtest_results';
+savedir2='D2_independantTtest_results2';
 xlab='Time (s)';
 ylab='Frequency (Hz)';
 Fs=500;

--- a/Examples/D2_pairedTtest.m
+++ b/Examples/D2_pairedTtest.m
@@ -19,8 +19,8 @@ effectNames={'Shoes'};
 % Data(:,1) correspond to Shoes=C1
 % Data(:,2) correspond to Shoes=C2
 
-savedir=[];
-savedir2=[];
+savedir='./D2_pairedTtest_results';
+savedir2='./D2_pairedTtest_results2';
 xlab='Time (s)';
 ylab='Frequency (Hz)';
 Fs=400;

--- a/Examples/D2_pairedTtest.m
+++ b/Examples/D2_pairedTtest.m
@@ -19,8 +19,8 @@ effectNames={'Shoes'};
 % Data(:,1) correspond to Shoes=C1
 % Data(:,2) correspond to Shoes=C2
 
-savedir='./D2_pairedTtest_results';
-savedir2='./D2_pairedTtest_results2';
+savedir='D2_pairedTtest_results';
+savedir2='D2_pairedTtest_results2';
 xlab='Time (s)';
 ylab='Frequency (Hz)';
 Fs=400;


### PR DESCRIPTION
Hi,

As part of my JOSS review, I ran the suggested example in the READM.md but was frustrated when I saw thhat I had to edit some paths, not right at the top of the file.

The simple changes seems to be to supply default paths so they run without edits... i.e. I changed the `[]` empty paths to `*_results` where `*` is the name of the example script.